### PR TITLE
Typo error corrected and inconsistency removed!

### DIFF
--- a/x-pack/winlogbeat/module/powershell/_meta/kibana/7/dashboard/c77e06c0-9e7c-11ea-af6f-cfdb1ee1d6c8.json
+++ b/x-pack/winlogbeat/module/powershell/_meta/kibana/7/dashboard/c77e06c0-9e7c-11ea-af6f-cfdb1ee1d6c8.json
@@ -1,6 +1,6 @@
 {
     "attributes": {
-        "description": "Overview dashboard por powershell module.",
+        "description": "Overview dashboard for PowerShell module.",
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
@@ -306,7 +306,7 @@
             }
         ],
         "timeRestore": false,
-        "title": "[Winlogbeat powershell] Overview",
+        "title": "[Winlogbeat PowerShell] Overview",
         "version": 1
     },
     "coreMigrationVersion": "7.14.0",


### PR DESCRIPTION
## What does this PR do?
This PR fixes the typo error and inconsistency mentioned in https://github.com/elastic/beats/issues/34291

Before: 
 "description": "Overview dashboard por powershell module."
 "title": "[Winlogbeat powershell] Overview", 

After:
 "description": "Overview dashboard `for` `PowerShell` module.", 
 "title": "[Winlogbeat `PowerShell`] Overview", 


#### Signed-off by : Agnivesh Chaubey <agniveshvapi@gmail.com>
